### PR TITLE
Issue1469 

### DIFF
--- a/araqne-logdb/src/main/java/org/araqne/logdb/query/command/EmptyCommand.java
+++ b/araqne-logdb/src/main/java/org/araqne/logdb/query/command/EmptyCommand.java
@@ -1,0 +1,15 @@
+package org.araqne.logdb.query.command;
+
+import org.araqne.logdb.DriverQueryCommand;
+public class EmptyCommand extends DriverQueryCommand  {
+
+	@Override
+	public void run() {
+		//DoNothing.
+	}
+
+	@Override
+	public String getName() {
+		return "empty";
+	}
+}


### PR DESCRIPTION
araqne/issue#1469
권한있는 테이블이 없을때, empty driver 커맨드를 수행해 0건을 결과로 줌.